### PR TITLE
Change Asset Directory

### DIFF
--- a/src/Carbon/CarbonMod.cs
+++ b/src/Carbon/CarbonMod.cs
@@ -6,6 +6,8 @@ using System.Runtime.Loader;
 using JetBrains.Annotations;
 using MonoMod.Cil;
 using MonoMod.RuntimeDetour;
+using ReLogic.Content.Sources;
+using TeamCatalyst.Carbon.API;
 using Terraria.ModLoader;
 using Terraria.ModLoader.Core;
 
@@ -55,6 +57,14 @@ namespace TeamCatalyst.Carbon {
                 throw new InvalidOperationException("CarbonMod is not loaded in a ModLoadContext.");
 
             return mlc.loadableTypes.SelectMany(x => x.Value).ToArray();
+        }
+
+        public override IContentSource CreateDefaultContentSource()
+        {
+            SmartContentSource source = new SmartContentSource(base.CreateDefaultContentSource());
+            source.AddDirectoryRedirect("Content", "Assets/Textures");
+            source.AddDirectoryRedirect("Common", "Assets/Textures");
+            return source;
         }
     }
 }

--- a/src/TeamCatalyst.Carbon.API/SmartContentSource.cs
+++ b/src/TeamCatalyst.Carbon.API/SmartContentSource.cs
@@ -1,0 +1,67 @@
+﻿using ReLogic.Content.Sources;
+using ReLogic.Content;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TeamCatalyst.Carbon.API
+{
+    /// <summary>
+    ///     A wrapper around a given <see cref="IContentSource"/> instance which
+    ///     allows for finer control over content loading.
+    /// </summary>
+    public class SmartContentSource : IContentSource
+    {
+        public IContentValidator ContentValidator
+        {
+            get => _source.ContentValidator;
+            set => _source.ContentValidator = value;
+        }
+
+        public RejectedAssetCollection Rejections => _source.Rejections;
+
+        private readonly IContentSource _source;
+        private readonly Dictionary<string, string> _redirects = new Dictionary<string, string>();
+
+        public SmartContentSource(IContentSource source)
+        {
+            _source = source;
+        }
+
+        public void AddDirectoryRedirect(string fromDir, string toDir)
+        {
+            _redirects.Add(fromDir, toDir);
+        }
+
+        private string RewritePath(string path)
+        {
+            foreach ((string from, string to) in _redirects)
+            {
+                if (path.StartsWith(from))
+                {
+                    return path.Replace(from, to);
+                }
+            }
+
+            return path;
+        }
+
+        IEnumerable<string> IContentSource.EnumerateAssets()
+        {
+            return _source.EnumerateAssets().Select(RewritePath);
+        }
+
+        string IContentSource.GetExtension(string assetName)
+        {
+            return _source.GetExtension(RewritePath(assetName));
+        }
+
+        Stream IContentSource.OpenStream(string fullAssetName)
+        {
+            return _source.OpenStream(RewritePath(fullAssetName));
+        }
+    }
+}


### PR DESCRIPTION
Changes autoloaded assets to pull from `Assets/Textures` instead of `Content` and `Common`.

Simply taken from [Hunt of the Old God](https://github.com/TohruKobayashi/CalamityHunt/blob/master/Common/Utilities/SmartContentSource.cs), but considering Tomat wrote it and there aren't that many other ways to do it, it should probably be fine?